### PR TITLE
Support conversion from Presto decimal type to string

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -677,7 +677,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 	case "boolean":
 		vv, err := scanNullBool(v)
 		return vv.Bool, err
-	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second":
+	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal":
 		vv, err := scanNullString(v)
 		return vv.String, err
 	case "tinyint", "smallint", "integer", "bigint":
@@ -699,14 +699,6 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return v, nil
-	case "decimal":
-		if v == nil {
-			return nil, nil
-		}
-		if value, ok := v.(string); ok {
-			return value, nil
-		}
-		return nil, fmt.Errorf("cannot convert %v (%T) to string", v, v)
 	default:
 		return nil, fmt.Errorf("type not supported: %q", c.typeName)
 	}

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -699,6 +699,14 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return v, nil
+	case "decimal":
+        if v == nil {
+            return nil,nil
+        }
+        if value, ok := v.(string); ok {
+            return value, nil
+        }
+        return nil, fmt.Errorf("cannot convert %v (%T) to string",v ,v)
 	default:
 		return nil, fmt.Errorf("type not supported: %q", c.typeName)
 	}

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -700,13 +700,13 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 		}
 		return v, nil
 	case "decimal":
-        if v == nil {
-            return nil,nil
-        }
-        if value, ok := v.(string); ok {
-            return value, nil
-        }
-        return nil, fmt.Errorf("cannot convert %v (%T) to string",v ,v)
+		if v == nil {
+			return nil, nil
+		}
+		if value, ok := v.(string); ok {
+			return value, nil
+		}
+		return nil, fmt.Errorf("cannot convert %v (%T) to string", v, v)
 	default:
 		return nil, fmt.Errorf("type not supported: %q", c.typeName)
 	}


### PR DESCRIPTION
When my user uses the presto Go client to query presto,when the table has decimal type, the query will be canceled automatic by the presto go client. I find the client does not support decimal type,so i add the code to support the type.

It's my first time to code Golang, so the code is ugly.