### PR TITLE
add the convert type decimal

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -699,6 +699,14 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return v, nil
+	case "decimal":
+		if v==nil{
+			return nil,nil
+		}
+		if value ,ok := v.(string);ok{
+			return value ,nil
+		}
+		return nil,fmt.Errorf("cannot convert %v (%T) to string",v,v)
 	default:
 		return nil, fmt.Errorf("type not supported: %q", c.typeName)
 	}


### PR DESCRIPTION

When I use the presto read data from hive, I  found presto-go-client can not convert decimal type of data, then I  added the type of decimal conversion same as the way of official source  , converted decimal to string, so that the user according to Its own needs to convert it to float64 or other types.