### PR TITLE
Don't consider EOF an error until you're actually reading results

### DIFF
--- a/presto/integration_test.go
+++ b/presto/integration_test.go
@@ -15,6 +15,7 @@ package presto
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"flag"
 	"os"
 	"strings"
@@ -330,6 +331,20 @@ func TestIntegrationTypeConversion(t *testing.T) {
 		&nullMap,
 	)
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestIntegrationNoResults(t *testing.T) {
+	db := integrationOpen(t)
+	rows, err := db.Query("SELECT 1 LIMIT 0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for rows.Next() {
+		t.Fatal(errors.New("Rows returned"))
+	}
+	if err = rows.Err(); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This makes this driver consistent with how other drivers handle queries that don't return results.