### PR TITLE
When the float value is NaN,should return NaN, if not the query will be canceled

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -1050,6 +1050,9 @@ func scanNullFloat64(v interface{}) (sql.NullFloat64, error) {
 	}
 	vv, ok := v.(float64)
 	if !ok {
+		if v == "NaN" {
+			return sql.NullFloat64{Valid: true, Float64: math.NaN()}, nil
+		}
 		return sql.NullFloat64{},
 			fmt.Errorf("cannot convert %v (%T) to float64", v, v)
 	}

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -1052,9 +1052,14 @@ func scanNullFloat64(v interface{}) (sql.NullFloat64, error) {
 	if !ok {
 		if v == "NaN" {
 			return sql.NullFloat64{Valid: true, Float64: math.NaN()}, nil
+		} else if v == "Infinity" {
+			return sql.NullFloat64{Valid: true, Float64: math.Inf(+1)}, nil
+		} else if v == "-Infinity" {
+			return sql.NullFloat64{Valid: true, Float64: math.Inf(-1)}, nil
+		} else {
+			return sql.NullFloat64{},
+				fmt.Errorf("cannot convert %v (%T) to float64", v, v)
 		}
-		return sql.NullFloat64{},
-			fmt.Errorf("cannot convert %v (%T) to float64", v, v)
 	}
 	return sql.NullFloat64{Valid: true, Float64: vv}, nil
 }

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -1050,15 +1050,15 @@ func scanNullFloat64(v interface{}) (sql.NullFloat64, error) {
 	}
 	vv, ok := v.(float64)
 	if !ok {
-		if v == "NaN" {
+		switch v {
+		case "NaN":
 			return sql.NullFloat64{Valid: true, Float64: math.NaN()}, nil
-		} else if v == "Infinity" {
+		case "Infinity":
 			return sql.NullFloat64{Valid: true, Float64: math.Inf(+1)}, nil
-		} else if v == "-Infinity" {
+		case "-Infinity":
 			return sql.NullFloat64{Valid: true, Float64: math.Inf(-1)}, nil
-		} else {
-			return sql.NullFloat64{},
-				fmt.Errorf("cannot convert %v (%T) to float64", v, v)
+		default:
+			return sql.NullFloat64{}, fmt.Errorf("cannot convert %v (%T) to float64", v, v)
 		}
 	}
 	return sql.NullFloat64{Valid: true, Float64: vv}, nil

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -1049,7 +1049,9 @@ func scanNullFloat64(v interface{}) (sql.NullFloat64, error) {
 		return sql.NullFloat64{}, nil
 	}
 	vv, ok := v.(float64)
-	if !ok {
+	if ok {
+		return sql.NullFloat64{Valid: true, Float64: vv}, nil
+	} else {
 		switch v {
 		case "NaN":
 			return sql.NullFloat64{Valid: true, Float64: math.NaN()}, nil
@@ -1061,7 +1063,7 @@ func scanNullFloat64(v interface{}) (sql.NullFloat64, error) {
 			return sql.NullFloat64{}, fmt.Errorf("cannot convert %v (%T) to float64", v, v)
 		}
 	}
-	return sql.NullFloat64{Valid: true, Float64: vv}, nil
+
 }
 
 // NullSliceFloat64 represents a slice of float64 that may be null.

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -1051,19 +1051,17 @@ func scanNullFloat64(v interface{}) (sql.NullFloat64, error) {
 	vv, ok := v.(float64)
 	if ok {
 		return sql.NullFloat64{Valid: true, Float64: vv}, nil
-	} else {
-		switch v {
-		case "NaN":
-			return sql.NullFloat64{Valid: true, Float64: math.NaN()}, nil
-		case "Infinity":
-			return sql.NullFloat64{Valid: true, Float64: math.Inf(+1)}, nil
-		case "-Infinity":
-			return sql.NullFloat64{Valid: true, Float64: math.Inf(-1)}, nil
-		default:
-			return sql.NullFloat64{}, fmt.Errorf("cannot convert %v (%T) to float64", v, v)
-		}
 	}
-
+	switch v {
+	case "NaN":
+		return sql.NullFloat64{Valid: true, Float64: math.NaN()}, nil
+	case "Infinity":
+		return sql.NullFloat64{Valid: true, Float64: math.Inf(+1)}, nil
+	case "-Infinity":
+		return sql.NullFloat64{Valid: true, Float64: math.Inf(-1)}, nil
+	default:
+		return sql.NullFloat64{}, fmt.Errorf("cannot convert %v (%T) to float64", v, v)
+	}
 }
 
 // NullSliceFloat64 represents a slice of float64 that may be null.


### PR DESCRIPTION
For example, the query results from Hive include NaN value and the column is float, the query will be canceled. The Picture shows that:

<img width="633" alt="_20180327144920" src="https://user-images.githubusercontent.com/4738595/37984626-575d2676-3229-11e8-94c6-d26de8d5e800.png">

the NaN will cause the query failed.