### PR TITLE
prepared statement syntax

### DIFF
--- a/presto/serial.go
+++ b/presto/serial.go
@@ -1,0 +1,129 @@
+package presto
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type UnsupportedArgError struct {
+	t string
+}
+
+func (e UnsupportedArgError) Error() string {
+	return fmt.Sprintf("presto: unsupported arg type: %s", e.t)
+}
+
+// Numeric is a string representation of a number, such as "10", "5.5" or in scientific form
+// If another string format is used it will error to serialise
+type Numeric string
+
+// Serial converts any supported value to its equivalent string for as a presto parameter
+// See https://prestodb.io/docs/current/language/types.html
+func Serial(v interface{}) (string, error) {
+	switch x := v.(type) {
+	case nil:
+		return "", UnsupportedArgError{"<nil>"}
+
+	// numbers convertible to int
+	case int8:
+		return strconv.Itoa(int(x)), nil
+	case int16:
+		return strconv.Itoa(int(x)), nil
+	case int32:
+		return strconv.Itoa(int(x)), nil
+	case int:
+		return strconv.Itoa(x), nil
+	case uint16:
+		return strconv.Itoa(int(x)), nil
+
+	case int64:
+		return strconv.FormatInt(x, 10), nil
+
+	case uint32:
+		return strconv.FormatUint(uint64(x), 10), nil
+	case uint:
+		return strconv.FormatUint(uint64(x), 10), nil
+	case uint64:
+		return strconv.FormatUint(x, 10), nil
+
+		// float32, float64 not supported because digit precision will easily cause large problems
+	case float32:
+		return "", UnsupportedArgError{"float32"}
+	case float64:
+		return "", UnsupportedArgError{"float64"}
+
+	case Numeric:
+		if _, err := strconv.ParseFloat(string(x), 64); err != nil {
+			return "", err
+		}
+		return string(x), nil
+
+		// note byte and uint are not supported, this is because byte is an alias for uint8
+		// if you were to use uint8 (as a number) it could be interpreted as a byte, so it is unsupported
+		// use string instead of byte and any other uint/int type for uint8
+	case byte:
+		return "", UnsupportedArgError{"byte/uint8"}
+
+	case bool:
+		return strconv.FormatBool(x), nil
+
+	case string:
+		return "'" + strings.Replace(x, "'", "''", -1) + "'", nil
+
+		// TODO - []byte should probably be matched to 'VARBINARY' in presto
+	case []byte:
+		return "", UnsupportedArgError{"[]byte"}
+
+		// time.Time and time.Duration not supported as time and date take several different formats in presto
+	case time.Time:
+		return "", UnsupportedArgError{"time.Time"}
+	case time.Duration:
+		return "", UnsupportedArgError{"time.Duration"}
+
+		// TODO - json.RawMesssage should probably be matched to 'JSON' in presto
+	case json.RawMessage:
+		return "", UnsupportedArgError{"json.RawMessage"}
+	}
+
+	if reflect.TypeOf(v).Kind() == reflect.Slice {
+		x := reflect.ValueOf(v)
+		if x.IsNil() {
+			return "", UnsupportedArgError{"[]<nil>"}
+		}
+
+		slice := make([]interface{}, x.Len())
+
+		for i := 0; i < x.Len(); i++ {
+			slice[i] = x.Index(i).Interface()
+		}
+
+		return serialSlice(slice)
+	}
+
+	if reflect.TypeOf(v).Kind() == reflect.Map {
+		// are presto MAPs indifferent to order? Golang maps are, if presto aren't then the two types can't be compatible
+		return "", UnsupportedArgError{"map"}
+	}
+
+	// TODO - consider the remaining types in https://prestodb.io/docs/current/language/types.html (Row, IP, ...)
+
+	return "", UnsupportedArgError{fmt.Sprintf("%T", v)}
+}
+
+func serialSlice(v []interface{}) (string, error) {
+	ss := make([]string, len(v))
+
+	for i, x := range v {
+		s, err := Serial(x)
+		if err != nil {
+			return "", err
+		}
+		ss[i] = s
+	}
+
+	return "ARRAY[" + strings.Join(ss, ", ") + "]", nil
+}

--- a/presto/serial_test.go
+++ b/presto/serial_test.go
@@ -1,0 +1,150 @@
+package presto
+
+import "testing"
+
+func TestSerial(t *testing.T) {
+	scenarios := []struct {
+		name           string
+		value          interface{}
+		expectedError  bool
+		expectedSerial string
+	}{
+		{
+			name:           "basic string",
+			value:          "hello world",
+			expectedSerial: `'hello world'`,
+		},
+		{
+			name:           "single quoted string",
+			value:          "hello world's",
+			expectedSerial: `'hello world''s'`,
+		},
+		{
+			name:           "double quoted string",
+			value:          `hello "world"`,
+			expectedSerial: `'hello "world"'`,
+		},
+		{
+			name:           "int8",
+			value:          int8(100),
+			expectedSerial: "100",
+		},
+		{
+			name:           "int16",
+			value:          int16(100),
+			expectedSerial: "100",
+		},
+		{
+			name:           "int32",
+			value:          int32(100),
+			expectedSerial: "100",
+		},
+		{
+			name:           "int",
+			value:          int(100),
+			expectedSerial: "100",
+		},
+		{
+			name:           "int64",
+			value:          int64(100),
+			expectedSerial: "100",
+		},
+		{
+			name:          "uint8",
+			value:         uint8(100),
+			expectedError: true,
+		},
+		{
+			name:           "uint16",
+			value:          uint16(100),
+			expectedSerial: "100",
+		},
+		{
+			name:           "uint32",
+			value:          uint32(100),
+			expectedSerial: "100",
+		},
+		{
+			name:           "uint",
+			value:          uint(100),
+			expectedSerial: "100",
+		},
+		{
+			name:           "uint64",
+			value:          uint64(100),
+			expectedSerial: "100",
+		},
+		{
+			name:          "byte",
+			value:         byte('a'),
+			expectedError: true,
+		},
+		{
+			name:           "valid Numeric",
+			value:          Numeric("10"),
+			expectedSerial: "10",
+		},
+		{
+			name:          "invalid Numeric",
+			value:         Numeric("not-a-number"),
+			expectedError: true,
+		},
+		{
+			name:           "bool true",
+			value:          true,
+			expectedSerial: "true",
+		},
+		{
+			name:           "bool false",
+			value:          false,
+			expectedSerial: "false",
+		},
+		{
+			name:          "nil",
+			value:         nil,
+			expectedError: true,
+		},
+		{
+			name:          "slice typed nil",
+			value:         []interface{}(nil),
+			expectedError: true,
+		},
+		{
+			name:           "valid slice",
+			value:          []interface{}{1, 2},
+			expectedSerial: "ARRAY[1, 2]",
+		},
+		{
+			name:           "valid empty",
+			value:          []interface{}{},
+			expectedSerial: "ARRAY[]",
+		},
+		{
+			name:          "invalid slice contents",
+			value:         []interface{}{1, byte('a')},
+			expectedError: true,
+		},
+	}
+
+	for i := range scenarios {
+		scenario := scenarios[i]
+
+		t.Run(scenario.name, func(t *testing.T) {
+			s, err := Serial(scenario.value)
+			if err != nil {
+				if scenario.expectedError {
+					return
+				}
+				t.Fatal(err)
+			}
+
+			if scenario.expectedError {
+				t.Fatal("missing an expected error")
+			}
+
+			if scenario.expectedSerial != s {
+				t.Fatalf("mismatched serial, got %q expected %q", s, scenario.expectedSerial)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Query parameters syntax as requested https://github.com/prestodb/presto-go-client/issues

Using the 'X-Presto-Prepared-Statement' header for queries with arguments.

Testing - 
The provided docker container for the prestodb has limited column formats. If more are added there the integration testing can be more thorough.