### PR TITLE
fix go get path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You need a working environment with Go installed and $GOPATH set.
 Download and install presto database/sql driver:
 
 ```bash
-go get github.com/prestodb/presto-go-client
+go get github.com/prestodb/presto-go-client/presto
 ```
 
 Make sure you have Git installed and in your $PATH.


### PR DESCRIPTION
Current go get path fails with following message.
```
ebyhr@ubuntu:~/GitHub/presto-go-client$ go get github.com/prestodb/presto-go-client
package github.com/prestodb/presto-go-client: no buildable Go source files in /home/ebyhr/go/src/github.com/prestodb/presto-go-client
```

After this commit.
```
ebyhr@ubuntu:~/GitHub/presto-go-client$ go get github.com/prestodb/presto-go-client/presto
ebyhr@ubuntu:~/GitHub/presto-go-client$ 
```