### PR TITLE
support ipaddress type as string

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -722,7 +722,7 @@ func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
 			return nil, err
 		}
 		return vv.Bool, err
-	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "unknown":
+	case "json", "char", "varchar", "varbinary", "interval year to month", "interval day to second", "decimal", "ipaddress", "unknown":
 		vv, err := scanNullString(v)
 		if !vv.Valid {
 			return nil, err


### PR DESCRIPTION
```
presto> show create table memory.default.t6;
           Create Table           
----------------------------------
 CREATE TABLE memory.default.t6 ( 
    c1 ipaddress                  
 )                                
(1 row)
presto> select * from memory.default.t6;
    c1    
----------
 10.0.0.1 
(1 row)
```

Short go program
```go
...
     rows, err := db.Query("select * from memory.default.t6")
     if err != nil {
        log.Fatal(err)
     }
     defer rows.Close()
     for rows.Next() {
     	 var name string
         if err := rows.Scan(&name); err != nil {
      	    log.Fatal(err)
	 }
	 fmt.Printf("%s\n", name)
     }
...
```

Current behavior
```
ebyhr@ubuntu:~/GitHub/presto-go-client$ go run gopresto.go
2018/06/03 20:17:30 type not supported: "ipaddress"
exit status 1
```

After this commit
```
ebyhr@ubuntu:~/GitHub/presto-go-client$ go run gopresto.go
10.0.0.1
```