### PR TITLE
Fix the headers in QueryContext

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -460,7 +460,7 @@ func (st *driverStmt) QueryContext(ctx context.Context, args []driver.NamedValue
 
 	if len(args) > 0 {
 		hs = make(http.Header)
-		hs.Add(preparedStatementHeader, preparedStatementName+"="+st.query)
+		hs.Add(preparedStatementHeader, preparedStatementName+"="+url.QueryEscape(st.query))
 
 		ss := make([]string, len(args))
 		for i, arg := range args {


### PR DESCRIPTION
This function sends prepared statement as part of X-Presto-Prepared-Statement HTTP header.
The value passed through it is `_presto_go=<sql prepared statement>`. Unescaped punctuation
and special characters break the query, commas definetely do.