### PR TITLE
Fix user auth

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -560,11 +560,14 @@ func (st *driverStmt) QueryContext(ctx context.Context, args []driver.NamedValue
 
 	if len(args) > 0 {
 		hs = make(http.Header)
+		var headerArgs []driver.NamedValue
 		if args[0].Name == prestoUserHeader {
 			st.user = args[0].Value.(string)
 			hs.Add(prestoUserHeader, st.user)
+			headerArgs = args[1:]
+		} else {
+			headerArgs = args
 		}
-		headerArgs := args[1:]
 		if len(headerArgs) > 0 {
 			hs.Add(preparedStatementHeader, preparedStatementName+"="+url.QueryEscape(st.query))
 			ss := make([]string, len(headerArgs))

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -219,6 +219,11 @@ func newConn(dsn string) (*Conn, error) {
 		}
 
 		kerberosClient.WithConfig(conf)
+
+		loginErr := kerberosClient.Login()
+		if loginErr != nil {
+			return nil, fmt.Errorf("presto: Error login to KDC: %v", loginErr)
+		}
 	}
 
 	var httpClient = http.DefaultClient


### PR DESCRIPTION
The commits address 2 issues.
1. Explicitly call Kerberos Login, even SetSPNEGOHeader did it 
2. Even DB connection should be reused by multiple times, instead, let the X-PRESTO-USER be set ONLY for the URI, we should make it empty in the URI, and each query should be able to be sent by a different user. Did that in the QueryContext.