### PR TITLE
default timezone

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -1306,7 +1306,7 @@ func parseNullTime(v string) (NullTime, error) {
 	var t time.Time
 	var err error
 	for _, layout := range timeLayouts {
-		t, err = time.Parse(layout, v)
+		t, err = time.ParseInLocation(layout, v, time.Local)
 		if err == nil {
 			return NullTime{Valid: true, Time: t}, nil
 		}

--- a/presto/presto_test.go
+++ b/presto/presto_test.go
@@ -65,8 +65,8 @@ func TestKerberosConfig(t *testing.T) {
 
 func TestInvalidKerberosConfig(t *testing.T) {
 	c := &Config{
-		PrestoURI:          "http://foobar@localhost:8090",
-		KerberosEnabled:    "true",
+		PrestoURI:       "http://foobar@localhost:8090",
+		KerberosEnabled: "true",
 	}
 	_, err := c.FormatDSN()
 	if err == nil {
@@ -263,12 +263,12 @@ func TestTypeConversion(t *testing.T) {
 		{
 			PrestoType:                       "date",
 			PrestoResponseUnmarshalledSample: "2017-07-10",
-			ExpectedGoValue:                  time.Date(2017, 7, 10, 0, 0, 0, 0, utc),
+			ExpectedGoValue:                  time.Date(2017, 7, 10, 0, 0, 0, 0, time.Local),
 		},
 		{
 			PrestoType:                       "time",
 			PrestoResponseUnmarshalledSample: "01:02:03.000",
-			ExpectedGoValue:                  time.Date(0, 1, 1, 1, 2, 3, 0, utc),
+			ExpectedGoValue:                  time.Date(0, 1, 1, 1, 2, 3, 0, time.Local),
 		},
 		{
 			PrestoType:                       "time with time zone",
@@ -278,7 +278,7 @@ func TestTypeConversion(t *testing.T) {
 		{
 			PrestoType:                       "timestamp",
 			PrestoResponseUnmarshalledSample: "2017-07-10 01:02:03.000",
-			ExpectedGoValue:                  time.Date(2017, 7, 10, 1, 2, 3, 0, utc),
+			ExpectedGoValue:                  time.Date(2017, 7, 10, 1, 2, 3, 0, time.Local),
 		},
 		{
 			PrestoType:                       "timestamp with time zone",
@@ -331,8 +331,8 @@ func TestSliceTypeConversion(t *testing.T) {
 		TestScanner                      func(t *testing.T, s sql.Scanner)
 	}{
 		{
-			GoType:                           "[]bool",
-			Scanner:                          &NullSliceBool{},
+			GoType:  "[]bool",
+			Scanner: &NullSliceBool{},
 			PrestoResponseUnmarshalledSample: []interface{}{true},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSliceBool)
@@ -342,8 +342,8 @@ func TestSliceTypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[]string",
-			Scanner:                          &NullSliceString{},
+			GoType:  "[]string",
+			Scanner: &NullSliceString{},
 			PrestoResponseUnmarshalledSample: []interface{}{"hello"},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSliceString)
@@ -353,8 +353,8 @@ func TestSliceTypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[]int64",
-			Scanner:                          &NullSliceInt64{},
+			GoType:  "[]int64",
+			Scanner: &NullSliceInt64{},
 			PrestoResponseUnmarshalledSample: []interface{}{float64(1)},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSliceInt64)
@@ -365,8 +365,8 @@ func TestSliceTypeConversion(t *testing.T) {
 		},
 
 		{
-			GoType:                           "[]float64",
-			Scanner:                          &NullSliceFloat64{},
+			GoType:  "[]float64",
+			Scanner: &NullSliceFloat64{},
 			PrestoResponseUnmarshalledSample: []interface{}{float64(1)},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSliceFloat64)
@@ -376,8 +376,8 @@ func TestSliceTypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[]time.Time",
-			Scanner:                          &NullSliceTime{},
+			GoType:  "[]time.Time",
+			Scanner: &NullSliceTime{},
 			PrestoResponseUnmarshalledSample: []interface{}{"2017-07-01"},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSliceTime)
@@ -387,8 +387,8 @@ func TestSliceTypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[]map[string]interface{}",
-			Scanner:                          &NullSliceMap{},
+			GoType:  "[]map[string]interface{}",
+			Scanner: &NullSliceMap{},
 			PrestoResponseUnmarshalledSample: []interface{}{map[string]interface{}{"hello": "world"}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSliceMap)
@@ -431,8 +431,8 @@ func TestSlice2TypeConversion(t *testing.T) {
 		TestScanner                      func(t *testing.T, s sql.Scanner)
 	}{
 		{
-			GoType:                           "[][]bool",
-			Scanner:                          &NullSlice2Bool{},
+			GoType:  "[][]bool",
+			Scanner: &NullSlice2Bool{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{true}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice2Bool)
@@ -442,8 +442,8 @@ func TestSlice2TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][]string",
-			Scanner:                          &NullSlice2String{},
+			GoType:  "[][]string",
+			Scanner: &NullSlice2String{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{"hello"}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice2String)
@@ -453,8 +453,8 @@ func TestSlice2TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][]int64",
-			Scanner:                          &NullSlice2Int64{},
+			GoType:  "[][]int64",
+			Scanner: &NullSlice2Int64{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{float64(1)}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice2Int64)
@@ -464,8 +464,8 @@ func TestSlice2TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][]float64",
-			Scanner:                          &NullSlice2Float64{},
+			GoType:  "[][]float64",
+			Scanner: &NullSlice2Float64{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{float64(1)}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice2Float64)
@@ -475,8 +475,8 @@ func TestSlice2TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][]time.Time",
-			Scanner:                          &NullSlice2Time{},
+			GoType:  "[][]time.Time",
+			Scanner: &NullSlice2Time{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{"2017-07-01"}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice2Time)
@@ -486,8 +486,8 @@ func TestSlice2TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][]map[string]interface{}",
-			Scanner:                          &NullSlice2Map{},
+			GoType:  "[][]map[string]interface{}",
+			Scanner: &NullSlice2Map{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{map[string]interface{}{"hello": "world"}}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice2Map)
@@ -536,8 +536,8 @@ func TestSlice3TypeConversion(t *testing.T) {
 		TestScanner                      func(t *testing.T, s sql.Scanner)
 	}{
 		{
-			GoType:                           "[][][]bool",
-			Scanner:                          &NullSlice3Bool{},
+			GoType:  "[][][]bool",
+			Scanner: &NullSlice3Bool{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{[]interface{}{true}}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice3Bool)
@@ -547,8 +547,8 @@ func TestSlice3TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][][]string",
-			Scanner:                          &NullSlice3String{},
+			GoType:  "[][][]string",
+			Scanner: &NullSlice3String{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{[]interface{}{"hello"}}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice3String)
@@ -558,8 +558,8 @@ func TestSlice3TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][][]int64",
-			Scanner:                          &NullSlice3Int64{},
+			GoType:  "[][][]int64",
+			Scanner: &NullSlice3Int64{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{[]interface{}{float64(1)}}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice3Int64)
@@ -569,8 +569,8 @@ func TestSlice3TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][][]float64",
-			Scanner:                          &NullSlice3Float64{},
+			GoType:  "[][][]float64",
+			Scanner: &NullSlice3Float64{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{[]interface{}{float64(1)}}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice3Float64)
@@ -580,8 +580,8 @@ func TestSlice3TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][][]time.Time",
-			Scanner:                          &NullSlice3Time{},
+			GoType:  "[][][]time.Time",
+			Scanner: &NullSlice3Time{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{[]interface{}{"2017-07-01"}}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice3Time)
@@ -591,8 +591,8 @@ func TestSlice3TypeConversion(t *testing.T) {
 			},
 		},
 		{
-			GoType:                           "[][][]map[string]interface{}",
-			Scanner:                          &NullSlice3Map{},
+			GoType:  "[][][]map[string]interface{}",
+			Scanner: &NullSlice3Map{},
 			PrestoResponseUnmarshalledSample: []interface{}{[]interface{}{[]interface{}{map[string]interface{}{"hello": "world"}}}},
 			TestScanner: func(t *testing.T, s sql.Scanner) {
 				v, _ := s.(*NullSlice3Map)


### PR DESCRIPTION
The result of the query in presto is serialized by json, and the problem of the local time zone is applied to the front-end interface.

```sql
select cast('2017-09-24' as date)
```

```
2017-09-24T00:00:00Z
```

```js
var moment = require("moment")
var t = moment('2017-09-24T00:00:00Z')
console.log(t.format(), t.format('YYYY-MM-DD HH:mm:ss'))
// "2017-09-24T08:00:00+08:00"
// "2017-09-24 08:00:00"
```

Need a default time zone setting like https://github.com/go-sql-driver/mysql#loc