### PR TITLE
Only execute a prepared statement when parameters exist

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -568,15 +568,16 @@ func (st *driverStmt) QueryContext(ctx context.Context, args []driver.NamedValue
 				st.user = s
 				hs.Add(prestoUserHeader, st.user)
 			} else {
-				if hs.Get(preparedStatementHeader) == "" {
-					hs.Add(preparedStatementHeader, preparedStatementName+"="+url.QueryEscape(st.query))
-				}
 				ss = append(ss, s)
 			}
 		}
-		query = "EXECUTE " + preparedStatementName + " USING " + strings.Join(ss, ", ")
+		if len(ss) > 0 {
+			if hs.Get(preparedStatementHeader) == "" {
+				hs.Add(preparedStatementHeader, preparedStatementName+"="+url.QueryEscape(st.query))
+			}
+			query = "EXECUTE " + preparedStatementName + " USING " + strings.Join(ss, ", ")
+		}
 	}
-
 	req, err := st.conn.newRequest("POST", st.conn.baseURL+"/v1/statement", strings.NewReader(query), hs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Problem: sending `X-Presto-User` as the sole `arg` results in a parse error on the server:
```
panic: presto: query failed (200 OK): "io.prestosql.sql.parser.ParsingException: line 1:26: mismatched input '<EOF>'. Expecting: <expression>"
```

The reason for this is that no prepared statement header is constructed when it doesn't encounter a non-header argument: 
```
input query: select sequence(0, 4)
args: [{X-Presto-User 1 tholland}]
body: EXECUTE _presto_go USING
headers: map[X-Presto-User:['tholland']]
panic: presto: query failed (200 OK): "io.prestosql.sql.parser.ParsingException: line 1:26: mismatched input '<EOF>'. Expecting: <expression>"
```

When a parameter is passed, then the header is added: 
```
input query: select sequence(0, ?)
args: [{ 1 4} {X-Presto-User 2 tholland}]
body: EXECUTE _presto_go USING 4
headers: map[X-Presto-Prepared-Statement:[_presto_go=select+sequence%280%2C+%3F%29] X-Presto-User:['tholland']]
0
1
2
3
4
```

Solution: only use a prepared statement when there is a parameter that needs to be interpolated
