### PR TITLE
Fix interval types by downcasing type for string matching

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -827,7 +827,7 @@ func parseType(name string) []string {
 
 // ConvertValue implements the driver.ValueConverter interface.
 func (c *typeConverter) ConvertValue(v interface{}) (driver.Value, error) {
-	switch c.parsedType[0] {
+	switch strings.ToLower(c.parsedType[0]) {
 	case "boolean":
 		vv, err := scanNullBool(v)
 		if !vv.Valid {


### PR DESCRIPTION
Found a small bug where Presto (tested using the [official Presto image](https://hub.docker.com/r/prestosql/presto)) returns interval type names in all capitals (e.g. `INTERVAL YEAR TO MONTH` versus `bigint`). Since this package compares the type names to lowercase strings, this PR will downcase type names to avoid case differences causing incorrect type name matching.