### PR TITLE
Add transaction support to presto go client

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -203,6 +203,7 @@ type Conn struct {
 var (
 	_ driver.Conn               = &Conn{}
 	_ driver.ConnPrepareContext = &Conn{}
+	_ driver.ConnBeginTx        = &Conn{}
 )
 
 func newConn(dsn string) (*Conn, error) {

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -96,13 +96,16 @@ var (
 )
 
 const (
-	preparedStatementHeader = "X-Presto-Prepared-Statement"
-	preparedStatementName   = "_presto_go"
-	prestoUserHeader        = "X-Presto-User"
-	prestoSourceHeader      = "X-Presto-Source"
-	prestoCatalogHeader     = "X-Presto-Catalog"
-	prestoSchemaHeader      = "X-Presto-Schema"
-	prestoSessionHeader     = "X-Presto-Session"
+	preparedStatementHeader        = "X-Presto-Prepared-Statement"
+	preparedStatementName          = "_presto_go"
+	prestoUserHeader               = "X-Presto-User"
+	prestoSourceHeader             = "X-Presto-Source"
+	prestoCatalogHeader            = "X-Presto-Catalog"
+	prestoSchemaHeader             = "X-Presto-Schema"
+	prestoSessionHeader            = "X-Presto-Session"
+	prestoTransactionHeader        = "X-Presto-Transaction-Id"
+	prestoStartedTransactionHeader = "X-Presto-Started-Transaction-Id"
+	prestoClearTransactionHeader   = "X-Presto-Clear-Transaction-Id"
 
 	KerberosEnabledConfig    = "KerberosEnabled"
 	kerberosKeytabPathConfig = "KerberosKeytabPath"
@@ -352,6 +355,33 @@ func (c *Conn) Begin() (driver.Tx, error) {
 	return nil, ErrOperationNotSupported
 }
 
+func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	args := []string{}
+	if opts.ReadOnly {
+		args = append(args, "READ ONLY")
+	}
+
+	level := sql.IsolationLevel(opts.Isolation)
+	if level != sql.LevelDefault {
+		err := verifyIsolationLevel(level)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, fmt.Sprintf("ISOLATION LEVEL %s", level.String()))
+	}
+
+	query := fmt.Sprintf("START TRANSACTION %s", strings.Join(args, ", "))
+	c.httpHeaders.Set(prestoTransactionHeader, "NONE")
+	stmt := &driverStmt{conn: c, query: query}
+	_, err := stmt.QueryContext(ctx, []driver.NamedValue{})
+	if err != nil {
+		c.httpHeaders.Del(prestoTransactionHeader)
+		return nil, err
+	}
+
+	return &driverTx{conn: c}, nil
+}
+
 // Prepare implements the driver.Conn interface.
 func (c *Conn) Prepare(query string) (driver.Stmt, error) {
 	return nil, driver.ErrSkip
@@ -416,6 +446,12 @@ func (c *Conn) roundTrip(ctx context.Context, req *http.Request) (*http.Response
 			}
 			switch resp.StatusCode {
 			case http.StatusOK:
+				if id := resp.Header.Get(prestoStartedTransactionHeader); id != "" {
+					c.httpHeaders.Set(prestoTransactionHeader, id)
+				} else if resp.Header.Get(prestoClearTransactionHeader) == "true" {
+					c.httpHeaders.Del(prestoTransactionHeader)
+				}
+
 				return resp, nil
 			case http.StatusServiceUnavailable:
 				resp.Body.Close()

--- a/presto/presto_test.go
+++ b/presto/presto_test.go
@@ -323,17 +323,6 @@ func TestUnsupportedExec(t *testing.T) {
 	}
 }
 
-func TestUnsupportedTransaction(t *testing.T) {
-	db, err := sql.Open("presto", "http://localhost:9")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer db.Close()
-	if _, err := db.Begin(); err == nil {
-		t.Fatal("unsupported transaction succeeded with no error")
-	}
-}
-
 func TestTypeConversion(t *testing.T) {
 	utc, err := time.LoadLocation("UTC")
 	if err != nil {

--- a/presto/transaction.go
+++ b/presto/transaction.go
@@ -1,0 +1,53 @@
+package presto
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+)
+
+type driverTx struct {
+	conn *Conn
+}
+
+func (t *driverTx) Commit() error {
+	if t.conn == nil {
+		return driver.ErrBadConn
+	}
+
+	ctx := context.Background()
+	stmt := &driverStmt{conn: t.conn, query: "COMMIT"}
+	_, err := stmt.QueryContext(ctx, []driver.NamedValue{})
+	if err != nil {
+		return err
+	}
+
+	t.conn = nil
+	return nil
+}
+
+func (t *driverTx) Rollback() error {
+	if t.conn == nil {
+		return driver.ErrBadConn
+	}
+
+	ctx := context.Background()
+	stmt := &driverStmt{conn: t.conn, query: "ROLLBACK"}
+	_, err := stmt.QueryContext(ctx, []driver.NamedValue{})
+	if err != nil {
+		return err
+	}
+
+	t.conn = nil
+	return nil
+}
+
+func verifyIsolationLevel(level sql.IsolationLevel) error {
+	switch level {
+	case sql.LevelRepeatableRead, sql.LevelReadCommitted, sql.LevelReadUncommitted, sql.LevelSerializable:
+		return nil
+	default:
+		return fmt.Errorf("presto: unsupported isolation level: %v", level)
+	}
+}

--- a/presto/transaction_test.go
+++ b/presto/transaction_test.go
@@ -1,0 +1,344 @@
+package presto
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type queryHandler struct {
+	url     string
+	body    string
+	handler func(w http.ResponseWriter, r *http.Request) (string, error)
+	matched bool
+}
+
+type testServer struct {
+	expectedQueries []*queryHandler
+}
+
+func (srv *testServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	bodyBytes, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(&stmtResponse{
+			Error: stmtError{
+				ErrorName: "BAD QUERY",
+			},
+		})
+		return
+	}
+
+	var nextURI string
+	body := string(bodyBytes)
+	err = fmt.Errorf("unexpected query %s", body)
+	for _, query := range srv.expectedQueries {
+		if query.url == r.RequestURI && query.body == body {
+			query.matched = true
+			nextURI, err = query.handler(w, r)
+			break
+		}
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(&stmtResponse{
+			Error: stmtError{
+				ErrorName: err.Error(),
+			},
+		})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(&stmtResponse{
+		ID:      "id",
+		NextURI: nextURI,
+	})
+}
+
+func (srv *testServer) verifyExpectedQueries() error {
+	for _, query := range srv.expectedQueries {
+		if !query.matched {
+			return fmt.Errorf("expected query not matched. url: %s, body: %s", query.body, query.url)
+		}
+	}
+
+	return nil
+}
+
+func checkRequestTransactionHeader(r *http.Request, id string) error {
+	headerValue := r.Header.Get(prestoTransactionHeader)
+	if headerValue == id {
+		return nil
+	}
+
+	return fmt.Errorf("unexpected transaction id in header. got: %s, expected: %s", headerValue, id)
+}
+
+func TestTransactionCommit(t *testing.T) {
+	server := &testServer{}
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+
+	transactionID := "123"
+	server.expectedQueries = []*queryHandler{
+		{
+			url:  "/v1/statement",
+			body: "START TRANSACTION READ ONLY, ISOLATION LEVEL Read Uncommitted",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, "NONE"); err != nil {
+					return "", err
+				}
+
+				return fmt.Sprintf("%s/%s", ts.URL, "start"), nil
+			},
+		},
+		{
+			url:  "/start",
+			body: "",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, "NONE"); err != nil {
+					return "", err
+				}
+
+				w.Header().Set(prestoStartedTransactionHeader, transactionID)
+				return "", nil
+			},
+		},
+		{
+			url:  "/v1/statement",
+			body: "SELECT * FROM TransactionTable",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, transactionID); err != nil {
+					return "", err
+				}
+
+				return fmt.Sprintf("%s/%s", ts.URL, "select_transaction"), nil
+			},
+		},
+		{
+			url:  "/select_transaction",
+			body: "",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, transactionID); err != nil {
+					return "", err
+				}
+
+				return "", nil
+			},
+		},
+		{
+			url:  "/v1/statement",
+			body: "COMMIT",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, transactionID); err != nil {
+					return "", err
+				}
+
+				return fmt.Sprintf("%s/%s", ts.URL, "commit"), nil
+			},
+		},
+		{
+			url:  "/commit",
+			body: "",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, transactionID); err != nil {
+					return "", err
+				}
+
+				w.Header().Set(prestoClearTransactionHeader, "true")
+				return "", nil
+			},
+		},
+		{
+			url:  "/v1/statement",
+			body: "SELECT * FROM NoTransactionTable",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, ""); err != nil {
+					return "", err
+				}
+
+				return fmt.Sprintf("%s/%s", ts.URL, "select_no_transaction"), nil
+			},
+		},
+		{
+			url:  "/select_no_transaction",
+			body: "",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, ""); err != nil {
+					return "", err
+				}
+
+				return "", nil
+			},
+		},
+	}
+
+	db, err := sql.Open("presto", ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true, Isolation: sql.LevelReadUncommitted})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	_, err = tx.Query("SELECT * FROM TransactionTable")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	_, err = db.Query("SELECT * FROM NoTransactionTable")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	err = server.verifyExpectedQueries()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
+func TestTransactionRollback(t *testing.T) {
+	server := &testServer{}
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+
+	transactionID := "123"
+	server.expectedQueries = []*queryHandler{
+		{
+			url:  "/v1/statement",
+			body: "START TRANSACTION READ ONLY, ISOLATION LEVEL Read Uncommitted",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, "NONE"); err != nil {
+					return "", err
+				}
+
+				return fmt.Sprintf("%s/%s", ts.URL, "start"), nil
+			},
+		},
+		{
+			url:  "/start",
+			body: "",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, "NONE"); err != nil {
+					return "", err
+				}
+
+				w.Header().Set(prestoStartedTransactionHeader, transactionID)
+				return "", nil
+			},
+		},
+		{
+			url:  "/v1/statement",
+			body: "SELECT * FROM TransactionTable",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, transactionID); err != nil {
+					return "", err
+				}
+
+				return fmt.Sprintf("%s/%s", ts.URL, "select_transaction"), nil
+			},
+		},
+		{
+			url:  "/select_transaction",
+			body: "",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, transactionID); err != nil {
+					return "", err
+				}
+
+				return "", nil
+			},
+		},
+		{
+			url:  "/v1/statement",
+			body: "ROLLBACK",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, transactionID); err != nil {
+					return "", err
+				}
+
+				return fmt.Sprintf("%s/%s", ts.URL, "rollback"), nil
+			},
+		},
+		{
+			url:  "/rollback",
+			body: "",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, transactionID); err != nil {
+					return "", err
+				}
+
+				w.Header().Set(prestoClearTransactionHeader, "true")
+				return "", nil
+			},
+		},
+		{
+			url:  "/v1/statement",
+			body: "SELECT * FROM NoTransactionTable",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, ""); err != nil {
+					return "", err
+				}
+
+				return fmt.Sprintf("%s/%s", ts.URL, "select_no_transaction"), nil
+			},
+		},
+		{
+			url:  "/select_no_transaction",
+			body: "",
+			handler: func(w http.ResponseWriter, r *http.Request) (string, error) {
+				if err := checkRequestTransactionHeader(r, ""); err != nil {
+					return "", err
+				}
+
+				return "", nil
+			},
+		},
+	}
+
+	db, err := sql.Open("presto", ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	tx, err := db.BeginTx(context.Background(), &sql.TxOptions{ReadOnly: true, Isolation: sql.LevelReadUncommitted})
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	_, err = tx.Query("SELECT * FROM TransactionTable")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	err = tx.Rollback()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	_, err = db.Query("SELECT * FROM NoTransactionTable")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	err = server.verifyExpectedQueries()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}


### PR DESCRIPTION
:wave: I hope you'll be open to accepting a PR to add transaction support to the presto go client.  I needed this support for a project I'm working on and thought it could be useful to others as well.

This PR adds support for transactions via Presto's REST API by setting/handling the headers `X-Presto-Transaction-Id`, `X-Presto-Started-Transaction-Id` and `X-Presto-Clear-Transaction-Id` as described in the documentation for [client](https://prestodb.io/docs/current/develop/client-protocol.html#client-request-headers) and [response](https://prestodb.io/docs/current/develop/client-protocol.html#client-response-headers) headers.  I opted to put the new code and tests into new files where it made sense rather than adding to `presto.go` as that file was getting a little long.  I'd be happy to move things around if preferred though, please let me know 🙏 !

The transaction starts by setting the `X-Presto-Transaction-Id` header to "NONE" in `Conn.BeginTx`, as I found in usage that the header needed to be set when creating a transaction and that value was allowable.  The `Started` and `Clear` headers are handled in `Conn.roundTrip` when handling a successful query response.

Testing is done with a relatively simplistic mock test http server that allows tests to set expected calls and responses.  I've added test cases to validate that headers are set as expected in requests, and handled as expected from responses.