### PR TITLE
add X-Presto-Client-Tags && give query  id by rows.Err

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -587,7 +587,7 @@ type stmtStage struct {
 	SubStages       []stmtStage `json:"subStages"`
 }
 
-// EOF indicates that a query is success, only for give QueryID.
+// EOF indicates the server has returned io.EOF for the given QueryID.
 type EOF struct {
 	QueryID string
 }

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -587,14 +587,14 @@ type stmtStage struct {
 	SubStages       []stmtStage `json:"subStages"`
 }
 
-// ErrQueryId indicates that a query is success, only for give QueryId.
-type ErrQueryId struct {
-	QueryId string
+// EOF indicates that a query is success, only for give QueryID.
+type EOF struct {
+	QueryID string
 }
 
 // Error implements the error interface.
-func (e *ErrQueryId) Error() string {
-	return e.QueryId
+func (e *EOF) Error() string {
+	return e.QueryID
 }
 
 func (st *driverStmt) Query(args []driver.Value) (driver.Rows, error) {
@@ -756,7 +756,7 @@ func (qr *driverRows) Next(dest []driver.Value) error {
 			qr.err = err
 		}
 		if qr.err == io.EOF {
-			return &ErrQueryId{QueryId: qr.id}
+			return &EOF{QueryID: qr.id}
 		}
 	}
 	if len(qr.coltype) == 0 {

--- a/presto/presto_test.go
+++ b/presto/presto_test.go
@@ -738,8 +738,6 @@ func TestNamedArgAndQueryId(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	var e *ErrQueryId
-
 	var testId string
 	for rows.Next() {
 		err := rows.Scan(&testId)
@@ -748,7 +746,8 @@ func TestNamedArgAndQueryId(t *testing.T) {
 		}
 	}
 
+	var e *EOF
 	if errors.As(rows.Err(), &e) {
-		t.Logf("sucess to get query ID: %s", e.QueryId)
+		t.Logf("sucess to get query ID: %s", e.QueryID)
 	}
 }

--- a/presto/presto_test.go
+++ b/presto/presto_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -195,7 +196,7 @@ func TestQueryContextCancellation(t *testing.T) {
 	var qr = queryResponse{
 		NextURI: "",
 		Columns: []queryColumn{},
-		Data: []queryData{},
+		Data:    []queryData{},
 		Stats: stmtStats{
 			State: "RUNNING",
 		},
@@ -723,5 +724,31 @@ func TestSlice3TypeConversion(t *testing.T) {
 			}
 			tc.TestScanner(t, tc.Scanner)
 		})
+	}
+}
+func TestNamedArgAndQueryId(t *testing.T) {
+	db, err := sql.Open("presto", "http://localhost:9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	rows, err := db.Query("select 1 ", sql.Named("X-Presto-Client-Tags", "userName=root"), sql.Named("X-Presto-Client-Info", "{\"submitTime\":\"2022-05-223 10:22:03\",\"userName\":\"root\"}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var e *ErrQueryId
+
+	var testId string
+	for rows.Next() {
+		err := rows.Scan(&testId)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if errors.As(rows.Err(), &e) {
+		t.Logf("sucess to get query ID: %s", e.QueryId)
 	}
 }


### PR DESCRIPTION
I hope you'll be open to accepting a PR to add queryId support to the presto go client. I needed this support for a project I'm working on and thought it could be useful to others as well.

Added X-presto-client-tags x-presto-client-info to distinguish clients and find problems easily。
We have a project to manage audit queries, as well as the records of queries, and desperately need queryId as a unique identifier, which is very useful for us

Tests have been done, please let me know if there are any problems