### PR TITLE
Return EOF when there are no results found in the query

### DIFF
--- a/presto/presto.go
+++ b/presto/presto.go
@@ -751,12 +751,13 @@ func (qr *driverRows) Next(dest []driver.Value) error {
 	if qr.columns == nil || qr.rowindex >= len(qr.data) {
 		if qr.nextURI == "" {
 			qr.err = io.EOF
+			return &EOF{QueryID: qr.id}
 		}
 		if err := qr.fetch(true); err != nil {
 			qr.err = err
-		}
-		if qr.err == io.EOF {
-			return &EOF{QueryID: qr.id}
+			if qr.err == io.EOF {
+				return &EOF{QueryID: qr.id}
+			}
 		}
 	}
 	if len(qr.coltype) == 0 {

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -758,6 +758,7 @@ func (qr *driverRows) Next(dest []driver.Value) error {
 			if qr.err == io.EOF {
 				return &EOF{QueryID: qr.id}
 			}
+			return qr.err
 		}
 	}
 	if len(qr.coltype) == 0 {


### PR DESCRIPTION
### What's the fix about
When having no results for the multiple rows query, `.Next()` panics. I believe the bug was introduced in this commit: [c3f935ff1cf9c69247d92e1e0b6016764f4bff8d](https://github.com/prestodb/presto-go-client/commit/c3f935ff1cf9c69247d92e1e0b6016764f4bff8d#diff-d263ebbbdec268da7c7a56a43b075f8b08e326708871fb0944537d8f094a1e2eL732-L738) .

### What's the approach
returning `EOF` solves the issue

### Current behaviour
Try querying multiple rows, it panics unexpectedly with `index out of range [0] with length 0` error. For example (from [go example](https://go.dev/doc/tutorial/database-access#multiple_rows)):
```
func albumsByArtist(artist string) ([]Album, error) {
    rows, err := db.Query("SELECT * FROM album WHERE artist = ?", artist)
    if err != nil {
        return nil, err
    }
    defer rows.Close()

    // An album slice to hold data from returned rows.
    var albums []Album

    // Loop through rows, using Scan to assign column data to struct fields.
    for rows.Next() {
        var alb Album
        if err := rows.Scan(&alb.ID, &alb.Title, &alb.Artist,
            &alb.Price, &alb.Quantity); err != nil {
            return albums, err
        }
        albums = append(albums, album)
    }
    if err = rows.Err(); err != nil {
        return albums, err
    }
    return albums, nil
}
```
### Expected behaviour
Shouldn't panic