### PR TITLE
feat: add jwt based authentication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Contributor License Agreement ("CLA")
 
-In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for one repository in the [prestodb](https://github.com/prestodb) organization, you're good to go. If you are submitting a pull request for the first time, the communitybridge-easycla bot will notify you if you haven't signed, and will provide you with a link.  If you are contributing on behalf of a company, you might want to let the person who manages your corporate CLA whitelist know they will be receiving a request from you.
+In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for one repository in the [prestodb](https://github.com/prestodb) organization, you're good to go. If you are submitting a pull request for the first time, the communitybridge-easycla bot will notify you if you haven't signed, and will provide you with a link. If you are contributing on behalf of a company, you might want to let the person who manages your corporate CLA whitelist know they will be receiving a request from you.
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Contributor License Agreement ("CLA")
 
-In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for one repository in the [prestodb](https://github.com/prestodb) organization, you're good to go. If you are submitting a pull request for the first time, the communitybridge-easycla bot will notify you if you haven't signed, and will provide you with a link. If you are contributing on behalf of a company, you might want to let the person who manages your corporate CLA whitelist know they will be receiving a request from you.
+In order to accept your pull request, we need you to submit a CLA. You only need to do this once, so if you've done this for one repository in the [prestodb](https://github.com/prestodb) organization, you're good to go. If you are submitting a pull request for the first time, the communitybridge-easycla bot will notify you if you haven't signed, and will provide you with a link.  If you are contributing on behalf of a company, you might want to let the person who manages your corporate CLA whitelist know they will be receiving a request from you.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ A [Presto](https://prestodb.io) client for the [Go](https://golang.org) programm
 
 ## Features
 
-- Native Go implementation
-- Connections over HTTP or HTTPS
-- HTTP Basic and Kerberos authentication
-- Per-query user information for access control
-- Support custom HTTP client (tunable conn pools, timeouts, TLS)
-- Supports conversion from Presto to native Go data types
-  - `string`, `sql.NullString`
-  - `int64`, `presto.NullInt64`
-  - `float64`, `presto.NullFloat64`
-  - `map`, `presto.NullMap`
-  - `time.Time`, `presto.NullTime`
-  - Up to 3-dimensional arrays to Go slices, of any supported type
+* Native Go implementation
+* Connections over HTTP or HTTPS
+* HTTP Basic and Kerberos authentication
+* Per-query user information for access control
+* Support custom HTTP client (tunable conn pools, timeouts, TLS)
+* Supports conversion from Presto to native Go data types
+  * `string`, `sql.NullString`
+  * `int64`, `presto.NullInt64`
+  * `float64`, `presto.NullFloat64`
+  * `map`, `presto.NullMap`
+  * `time.Time`, `presto.NullTime`
+  * Up to 3-dimensional arrays to Go slices, of any supported type
 
 ## Requirements
 
-- Go 1.18 or newer
-- Presto 0.16x or newer
+* Go 1.18 or newer
+* Presto 0.16x or newer
 
 ## Installation
 
@@ -39,7 +39,7 @@ Make sure you have Git installed and in your $PATH.
 
 ## Usage
 
-This Presto client is an implementation of Go's `database/sql/driver` interface. In order to use it, you need to import the package and use the [`database/sql`](https://golang.org/pkg/database/sql/) API then.
+This Presto client is an implementation of Go's `database/sql/driver` interface. In order to use it, you need to import the package and use the  [`database/sql`](https://golang.org/pkg/database/sql/) API then.
 
 Only read operations are supported, such as SHOW and SELECT.
 
@@ -105,7 +105,7 @@ The driver supports both HTTP and HTTPS. If you use HTTPS it's recommended that 
 
 #### Parameters
 
-_Parameters are case-sensitive_
+*Parameters are case-sensitive*
 
 Refer to the [Presto Concepts](https://prestodb.io/docs/current/overview/concepts.html) documentation for more information.
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ HTTP Basic authentication **is only supported on encrypted connections over HTTP
 
 This driver supports Kerberos authentication by setting up the Kerberos fields in the [Config](https://godoc.org/github.com/prestodb/presto-go-client/presto#Config) struct.
 
+Please refer to the [Coordinator Kerberos Authentication](https://prestodb.io/docs/current/security/server.html) for server-side configuration.
+
 #### JWT authentication
 
 This driver supports JWT authentication by setting the `AccessToken` field in the configuration. Simply add the query parameter with the JWT bearer token to be used for authentication. This token will then be sent as a bearer token for all HTTP requests.
 
 This authentication method has lower precedence than HTTP basic authentication.
-
-Please refer to the [Coordinator Kerberos Authentication](https://prestodb.io/docs/current/security/server.html) for server-side configuration.
 
 #### System access control and per-query user information
 

--- a/README.md
+++ b/README.md
@@ -7,23 +7,23 @@ A [Presto](https://prestodb.io) client for the [Go](https://golang.org) programm
 
 ## Features
 
-* Native Go implementation
-* Connections over HTTP or HTTPS
-* HTTP Basic and Kerberos authentication
-* Per-query user information for access control
-* Support custom HTTP client (tunable conn pools, timeouts, TLS)
-* Supports conversion from Presto to native Go data types
-  * `string`, `sql.NullString`
-  * `int64`, `presto.NullInt64`
-  * `float64`, `presto.NullFloat64`
-  * `map`, `presto.NullMap`
-  * `time.Time`, `presto.NullTime`
-  * Up to 3-dimensional arrays to Go slices, of any supported type
+- Native Go implementation
+- Connections over HTTP or HTTPS
+- HTTP Basic and Kerberos authentication
+- Per-query user information for access control
+- Support custom HTTP client (tunable conn pools, timeouts, TLS)
+- Supports conversion from Presto to native Go data types
+  - `string`, `sql.NullString`
+  - `int64`, `presto.NullInt64`
+  - `float64`, `presto.NullFloat64`
+  - `map`, `presto.NullMap`
+  - `time.Time`, `presto.NullTime`
+  - Up to 3-dimensional arrays to Go slices, of any supported type
 
 ## Requirements
 
-* Go 1.18 or newer
-* Presto 0.16x or newer
+- Go 1.18 or newer
+- Presto 0.16x or newer
 
 ## Installation
 
@@ -39,7 +39,7 @@ Make sure you have Git installed and in your $PATH.
 
 ## Usage
 
-This Presto client is an implementation of Go's `database/sql/driver` interface. In order to use it, you need to import the package and use the  [`database/sql`](https://golang.org/pkg/database/sql/) API then.
+This Presto client is an implementation of Go's `database/sql/driver` interface. In order to use it, you need to import the package and use the [`database/sql`](https://golang.org/pkg/database/sql/) API then.
 
 Only read operations are supported, such as SHOW and SELECT.
 
@@ -57,7 +57,7 @@ db, err := sql.Open("presto", dsn)
 
 ### Authentication
 
-Both HTTP Basic and Kerberos authentication are supported.
+HTTP Basic, Kerberos, and JWT authentication are supported.
 
 #### HTTP Basic authentication
 
@@ -68,6 +68,12 @@ HTTP Basic authentication **is only supported on encrypted connections over HTTP
 #### Kerberos authentication
 
 This driver supports Kerberos authentication by setting up the Kerberos fields in the [Config](https://godoc.org/github.com/prestodb/presto-go-client/presto#Config) struct.
+
+#### JWT authentication
+
+This driver supports JWT authentication by setting the `AccessToken` field in the configuration. Simply add the query parameter with the JWT bearer token to be used for authentication. This token will then be sent as a bearer token for all HTTP requests.
+
+This authentication method has lower precedence than HTTP basic authentication.
 
 Please refer to the [Coordinator Kerberos Authentication](https://prestodb.io/docs/current/security/server.html) for server-side configuration.
 
@@ -99,7 +105,7 @@ The driver supports both HTTP and HTTPS. If you use HTTPS it's recommended that 
 
 #### Parameters
 
-*Parameters are case-sensitive*
+_Parameters are case-sensitive_
 
 Refer to the [Presto Concepts](https://prestodb.io/docs/current/overview/concepts.html) documentation for more information.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Please refer to the [Coordinator Kerberos Authentication](https://prestodb.io/do
 
 #### JWT authentication
 
-This driver supports JWT authentication by setting the `AccessToken` field in the configuration. Simply add the query parameter with the JWT bearer token to be used for authentication. This token will then be sent as a bearer token for all HTTP requests.
+This driver supports JWT authentication by setting the `AccessToken` field in the configuration. Add the query parameter with the JWT bearer token to be used for authentication. This token will then be sent as a bearer token for all HTTP requests.
 
 This authentication method has lower precedence than HTTP basic authentication.
 

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -109,14 +109,14 @@ const (
 	prestoClientTagsHeader         = "X-Presto-Client-Tags"
 	prestoClientInfoHeader         = "X-Presto-Client-Info"
 
-	KerberosEnabledConfig    = "KerberosEnabled"
+	kerberosEnabledConfig    = "KerberosEnabled"
 	kerberosKeytabPathConfig = "KerberosKeytabPath"
 	kerberosPrincipalConfig  = "KerberosPrincipal"
 	kerberosRealmConfig      = "KerberosRealm"
 	kerberosConfigPathConfig = "KerberosConfigPath"
-	SSLCertPathConfig        = "SSLCertPath"
+	sSLCertPathConfig        = "SSLCertPath"
 
-	AccessToken = "AccessToken"
+	accessTokenConfig = "AccessToken"
 )
 
 type sqldriver struct{}
@@ -167,11 +167,11 @@ func (c *Config) FormatDSN() (string, error) {
 	isSSL := prestoURL.Scheme == "https"
 
 	if isSSL && c.SSLCertPath != "" {
-		query.Add(SSLCertPathConfig, c.SSLCertPath)
+		query.Add(sSLCertPathConfig, c.SSLCertPath)
 	}
 
 	if KerberosEnabled {
-		query.Add(KerberosEnabledConfig, "true")
+		query.Add(kerberosEnabledConfig, "true")
 		query.Add(kerberosKeytabPathConfig, c.KerberosKeytabPath)
 		query.Add(kerberosPrincipalConfig, c.KerberosPrincipal)
 		query.Add(kerberosRealmConfig, c.KerberosRealm)
@@ -182,7 +182,7 @@ func (c *Config) FormatDSN() (string, error) {
 	}
 
 	if c.AccessToken != "" {
-		query.Add(AccessToken, c.AccessToken)
+		query.Add(accessTokenConfig, c.AccessToken)
 	}
 
 	for k, v := range map[string]string{
@@ -223,7 +223,7 @@ func newConn(dsn string) (*Conn, error) {
 
 	prestoQuery := prestoURL.Query()
 
-	kerberosEnabled, _ := strconv.ParseBool(prestoQuery.Get(KerberosEnabledConfig))
+	kerberosEnabled, _ := strconv.ParseBool(prestoQuery.Get(kerberosEnabledConfig))
 
 	var kerberosClient client.Client
 
@@ -253,7 +253,7 @@ func newConn(dsn string) (*Conn, error) {
 		if httpClient == nil {
 			return nil, fmt.Errorf("presto: custom client not registered: %q", clientKey)
 		}
-	} else if certPath := prestoQuery.Get(SSLCertPathConfig); certPath != "" && prestoURL.Scheme == "https" {
+	} else if certPath := prestoQuery.Get(sSLCertPathConfig); certPath != "" && prestoURL.Scheme == "https" {
 		cert, err := os.ReadFile(certPath)
 		if err != nil {
 			return nil, fmt.Errorf("presto: Error loading SSL Cert File: %v", err)
@@ -300,8 +300,8 @@ func newConn(dsn string) (*Conn, error) {
 	}
 
 	// if a JWT access token is provided, add an Authorization header with Bearer token
-	if prestoQuery.Get(AccessToken) != "" {
-		c.httpHeaders.Set("Authorization", "Bearer "+prestoQuery.Get(AccessToken))
+	if token := prestoQuery.Get(accessTokenConfig); token != "" {
+		c.httpHeaders.Set("Authorization", "Bearer "+token)
 	}
 
 	return c, nil

--- a/presto/presto_test.go
+++ b/presto/presto_test.go
@@ -357,7 +357,10 @@ func TestJWTAuthHeader(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer db.Close()
-	db.Query("SELECT 1")
+	_, err = db.Query("SELECT 1")
+	if err.Error() != "presto: EOF" {
+		t.Fatal("expected query to return EOF", err)
+	}
 }
 
 func TestTypeConversion(t *testing.T) {

--- a/presto/presto_test.go
+++ b/presto/presto_test.go
@@ -346,9 +346,10 @@ func TestJWTAuthHeader(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// validate the Authorization header is JWT token
 		if r.Header.Get("Authorization") != "Bearer test_token" {
-			t.Fatal("unexpected Authorization header, want JWT token")
+			w.WriteHeader(http.StatusUnauthorized)
+		} else {
+			w.WriteHeader(http.StatusOK)
 		}
-		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
 

--- a/presto/presto_test.go
+++ b/presto/presto_test.go
@@ -107,6 +107,23 @@ func TestInvalidKerberosConfig(t *testing.T) {
 	}
 }
 
+func TestJWTConfig(t *testing.T) {
+	c := &Config{
+		PrestoURI:         "https://foobar@localhost:8090",
+		SessionProperties: map[string]string{"query_priority": "1"},
+		AccessToken:       "test_token",
+	}
+	dsn, err := c.FormatDSN()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "https://foobar@localhost:8090?AccessToken=test_token&session_properties=query_priority%3D1&source=presto-go-client"
+	if dsn != want {
+		t.Fatal("unexpected dsn:", dsn)
+	}
+}
+
 func TestConfigWithMalformedURL(t *testing.T) {
 	_, err := (&Config{PrestoURI: ":("}).FormatDSN()
 	if err == nil {
@@ -322,6 +339,25 @@ func TestUnsupportedExec(t *testing.T) {
 	if _, err := db.Exec("CREATE TABLE foobar (V VARCHAR)"); err == nil {
 		t.Fatal("unsupported exec succeeded with no error")
 	}
+}
+
+func TestJWTAuthHeader(t *testing.T) {
+	// this test ensures that the JWT token is passed as a Bearer token within the Authorization header
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// validate the Authorization header is JWT token
+		if r.Header.Get("Authorization") != "Bearer test_token" {
+			t.Fatal("unexpected Authorization header, want JWT token")
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	db, err := sql.Open("presto", ts.URL+"?AccessToken=test_token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	db.Query("SELECT 1")
 }
 
 func TestTypeConversion(t *testing.T) {


### PR DESCRIPTION
### context

 JWT based authentication is gaining popularity as a form of authentication. It's commonly used as part of flow at the proxy layer (for ex. envoy proxy). This PR aims to address #76 and add support for JWT based authentication to the presto go client.

### implementation

The implementation adds another Config field, "AccessToken" which can be provided as a query parameter. This token will then be added as a Bearer token as part of the Authorization header. If basic authentication is provided, it should take precedent over the AccessToken 